### PR TITLE
Increase Vagrant VM memory from 3GB to 4GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure("2") do |config|
 
     # VirtualBox settings
     worker.vm.provider :virtualbox do |vb|
-      vb.customize ["modifyvm", :id, "--memory", "3048"]
+      vb.customize ["modifyvm", :id, "--memory", "4096"]
       vb.cpus = 8
     end
 


### PR DESCRIPTION
Running `sbt` on a freshly provisioned VM returned an error

```
vagrant@vagrant-ubuntu-trusty-64:~/geotrellis$ ./sbt
Detected sbt version 0.13.5
Starting sbt: invoke with -help for other options
Using /home/vagrant/.sbt/0.13.5 as sbt dir, -sbt-dir to override.
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000a0000000, 1073741824, 0) failed; error='Cannot allocate memory' (errno=12)
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (malloc) failed to allocate 1073741824 bytes for committing reserved memory.
# An error report file with more information is saved as:
# /home/vagrant/geotrellis/hs_err_pid4841.log
```

Increasing the VM memory to 4GB allowed for a successful launch of `sbt`
